### PR TITLE
#13: Update project for latest development tools

### DIFF
--- a/Pragmatic.xcodeproj/project.pbxproj
+++ b/Pragmatic.xcodeproj/project.pbxproj
@@ -211,26 +211,26 @@
 			attributes = {
 				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					D2AAF87E1E465838000EFE1F = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = UPXU4CQZ5P;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1320;
 						ProvisioningStyle = Automatic;
 					};
 					D2AAF8921E465877000EFE1F = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = UPXU4CQZ5P;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1320;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = D2AAF87A1E465838000EFE1F /* Build configuration list for PBXProject "Pragmatic" */;
 			compatibilityVersion = "Xcode 8.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -326,6 +326,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -333,8 +334,10 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -365,6 +368,7 @@
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -381,6 +385,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -388,8 +393,10 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -412,6 +419,7 @@
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -425,7 +433,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinitenexus.PragmaticXcode;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -439,7 +447,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinitenexus.PragmaticXcode;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -454,7 +462,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinitenexus.PragmaticXcode.Pragmatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -469,7 +477,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinitenexus.PragmaticXcode.Pragmatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Pragmatic Usage Demo](Resources/demo.gif)
 
 [![GitHub release](https://img.shields.io/github/release/bgannin/Pragmatic.svg)](https://github.com/bgannin/Pragmatic/releases)
-[![Language](https://img.shields.io/badge/language-Swift%204.0-orange.svg)](https://swift.org/)
+[![Language](https://img.shields.io/badge/language-Swift%205.5-orange.svg)](https://swift.org/)
 [![License](https://img.shields.io/badge/license-MIT-red.svg)](https://github.com/bgannin/Pragmatic/blob/master/LICENSE)
 
 ## Features
@@ -27,14 +27,12 @@
 
 ## Supported Xcode
 
-- Xcode 8.x
-- Xcode 9.x
+- Xcode 13.x-
 
 ## Supported OSes
 
-- OS X 10.11 *(El Capitan)*
-- macOS 10.12 *(Sierra)*
-- macOS 10.13 *(High Sierra)*
+- macOS 10.14 *(Big Sur)*
+- macOS 10.15 *(Monterrey)*
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 ## Supported OSes
 
-- macOS 10.14 *(Big Sur)*
-- macOS 10.15 *(Monterrey)*
+- macOS 11.x *(Big Sur)*
+- macOS 12.x *(Monterrey)*
 
 ## Tips
 


### PR DESCRIPTION
Update project settings and whatnot for 2021/2022. Clean build, tested on macOS 12.1 with Xcode 13.2.1.